### PR TITLE
chore(deps): bump postgres from 11.6 to 13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM postgres:11.6
+FROM postgres:13.3


### PR DESCRIPTION
Bumps postgres from 11.6 to 13.3.

Signed-off-by: dependabot[bot] <support@github.com>